### PR TITLE
Fix the example

### DIFF
--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -94,7 +94,7 @@ It is recommended using Maven's variable substitution to make the file easier to
 <skin>
    <groupId>${project.groupId}</groupId>
    <artifactId>${project.artifactId}</artifactId>
-   <version>${symbol_dollar}{project.version}</version>
+   <version>${symbol_dollar}{site.skin.version}</version>
 </skin>
 ```
 


### PR DESCRIPTION
>  It is recommended using Maven's variable substitution to make the file easier to mantain. For example by setting the *site.skin.version* property in the POM the skin configuration ends looking like this:

I think you meant to use `site.skin.version` in the xml hunk?