### PR TITLE
Upgrading to Font Awesome 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,11 @@
    "requires": true,
    "lockfileVersion": 1,
    "dependencies": {
+      "@fortawesome/fontawesome-free": {
+         "version": "5.15.3",
+         "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.3.tgz",
+         "integrity": "sha512-rFnSUN/QOtnOAgqFRooTA3H57JLDm0QEG/jPdk+tLQNL/eWd+Aok8g3qCI+Q1xuDPWpGW/i9JySpJVsq8Q0s9w=="
+      },
       "balanced-match": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -67,11 +72,6 @@
             "clone": "~2.1.0",
             "parserlib": "~1.1.1"
          }
-      },
-      "font-awesome": {
-         "version": "4.7.0",
-         "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-         "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
       },
       "fs.realpath": {
          "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
       "minify-css": "./node_modules/.bin/cleancss ./src/main/resources/css/*.css -o ./target/classes/css/style.min.css"
    },
    "dependencies": {
+      "@fortawesome/fontawesome-free": "~5.15.3",
       "bootstrap": "~4.5.3",
       "bootswatch": "~4.5.3",
       "clean-css-cli": "~4.3.0",
       "csslint": "~1.0.5",
-      "font-awesome": "~4.7.0",
       "html5shiv": "~3.7.3",
       "jquery": "~3.5.1"
    }

--- a/pom.xml
+++ b/pom.xml
@@ -338,10 +338,16 @@
                            <includes>
                               <include>bootstrap/dist/js/bootstrap.min.js</include>
                               <include>bootswatch/dist/*/bootstrap.min.css</include>
-                              <include>font-awesome/css/font-awesome.min.css</include>
-                              <include>font-awesome/fonts/*.*</include>
                               <include>html5shiv/dist/html5shiv.min.js</include>
                               <include>jquery/dist/jquery.min.js</include>
+                           </includes>
+                        </resource>
+                        <resource>
+                           <directory>node_modules/@fortawesome/fontawesome-free</directory>
+                           <targetPath>font-awesome</targetPath>
+                           <includes>
+                              <include>css/all.min.css</include>
+                              <include>webfonts/*.*</include>
                            </includes>
                         </resource>
                      </resources>

--- a/src/main/resources/META-INF/maven/macros/menu-macros.vm
+++ b/src/main/resources/META-INF/maven/macros/menu-macros.vm
@@ -59,7 +59,7 @@
 #macro( iconsMenu $elements )
 #**##foreach( $element in $elements )
 #*    *##foreach( $item in $element.items )
-            <a href="$item.href" title="$item.name" aria-label="$item.name"><span class="navbar-icon fa fa-$item.img pl-1" aria-hidden="true"></span> <span class="d-none d-sm-block d-md-none"> $item.name</span></a>
+            <a href="$item.href" title="$item.name" aria-label="$item.name"><span class="navbar-icon $item.img pl-1" aria-hidden="true"></span> <span class="d-none d-sm-block d-md-none"> $item.name</span></a>
 #*    *##end
 #**##end
 #end

--- a/src/main/resources/META-INF/maven/site.vm
+++ b/src/main/resources/META-INF/maven/site.vm
@@ -89,7 +89,7 @@
   #set( $bootswatchStyle = "litera" )
 #end
     <link rel="stylesheet" href="./lib/bootswatch/dist/${bootswatchStyle}/bootstrap.min.css">
-    <link rel="stylesheet" href="./lib/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="./lib/font-awesome/css/all.min.css">
 #if ( $config.customHighlightStyle )
   #set( $customHighlightStyle = $config.customHighlightStyle.getValue() )
 #else

--- a/src/site/markdown/custom_site_descriptor.md
+++ b/src/site/markdown/custom_site_descriptor.md
@@ -79,13 +79,13 @@ For this to work you just need to add an image attribute to the menu item:
 <body>
    ...
    <menu name="Icons" inherit="bottom">
-      <item name="Github" img="github" href="${project.scm.url}" />
+      <item name="Github" img="fab fa-github" href="${project.scm.url}" />
    </menu>
    ...
 </body>
 ```
 
-This image is a reference to an existing Font Awesome icon, without the fa- prefix, as this will be added automatically. In this case the icon picked will be fa-github.
+This image is a reference to an existing Font Awesome 5 icon. For the [GitHub icon](https://fontawesome.com/icons/github), image is set to `fab fa-github`.
 
 #### Descriptions for the Bottom Nav
 

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -82,7 +82,7 @@ The following example for a site.xml file will be useful for most sites:
          <item name="Maven Central" href="${mavenURL}" />
       </menu>
       <menu name="Icons" inherit="bottom">
-         <item name="Github" img="github" href="${project.scm.url}" />
+         <item name="Github" img="fab fa-github" href="${project.scm.url}" />
       </menu>
    </body>
 </project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -66,7 +66,7 @@
          <item name="Maven Central" href="${mavenURL}" />
       </menu>
       <menu name="Icons" inherit="bottom">
-         <item name="Github" img="github" href="${project.scm.url}" />
+         <item name="Github" img="fab fa-github" href="${project.scm.url}" />
       </menu>
    </body>
 

--- a/src/test/resources/it/icons_list/src/site/site.xml
+++ b/src/test/resources/it/icons_list/src/site/site.xml
@@ -18,7 +18,7 @@
 
    <body>
       <menu name="Icons" inherit="bottom">
-         <item name="Github" img="github" href="${project.scm.url}" />
+         <item name="Github" img="fab fa-github" href="${project.scm.url}" />
       </menu>
    </body>
 

--- a/src/test/resources/it/resources/verify.groovy
+++ b/src/test/resources/it/resources/verify.groovy
@@ -4,7 +4,7 @@
 [
     'target/site/lib/bootstrap/dist/js/bootstrap.min.js',
     'target/site/lib/bootswatch/dist/litera/bootstrap.min.css',
-    'target/site/lib/font-awesome/css/font-awesome.min.css',
+    'target/site/lib/font-awesome/css/all.min.css',
     'target/site/lib/html5shiv/dist/html5shiv.min.js',
     'target/site/lib/jquery/dist/jquery.min.js',
     'target/site/lib/highlight/highlight.pack.js'


### PR DESCRIPTION
First, I'd like to say I'm really enjoying this skin. I'm building out my first Maven site with it now and it's going really well. Thanks for making such a cool piece of software. 

Font Awesome has moved on to v5 and v6 is in alpha. There were some new icons I was trying to use that don't exist in v4. It doesn't sounds like Font Awesome has any intention to continue maintaining v4. I thought I would offer a quick upgrade PR and was feeling pretty optimistic about it... until I realized Font Awesome v5 is not a drop-in replacement for this project. Still, I figured it might be worth seeing the PR through and asking if this is something you would be interested in. 🙂 

This PR does upgrade to v5 but with a breaking change. In v5, some icons have different prefixes depending on which icon you want. The template, however, assumes everything uses prefix `fa`.  For example `fa fa-github` has changed to `fab fa-github`.

The solution I took first was to push the responsibility of providing the full class names onto the user. This way they can select the appropriate prefix for their icon. This also opens the door for users with a Pro license for Font Awesome.

I would completely understand if you want to pass because it is a breaking change. Either way, thanks for taking time to look at this. 